### PR TITLE
Ignore comment lines when executing script on Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSQLite.java
+++ b/android/src/main/java/com/getcapacitor/community/database/sqlite/SQLite/UtilsSQLite.java
@@ -63,7 +63,16 @@ public class UtilsSQLite {
             String[] array = sqlCmdArray[i].split("\n");
             StringBuilder builder = new StringBuilder();
             for (String s : array) {
-                builder.append(" ").append(s.trim());
+                String line = s.trim();
+                if (line.startsWith("--")) {
+                    // is a comment, do nothing
+                } else if (s.length() > 0) {
+                    if (builder.length() > 0) {
+                        builder.append(" ");
+                    }
+                    builder.append(s);
+                }
+
             }
             sqlCmdArray[i] = builder.toString();
         }

--- a/android/src/test/java/com/getcapacitor/ExampleUnitTest.java
+++ b/android/src/test/java/com/getcapacitor/ExampleUnitTest.java
@@ -1,6 +1,9 @@
 package com.getcapacitor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import com.getcapacitor.community.database.sqlite.SQLite.UtilsSQLite;
 
 import org.junit.Test;
 
@@ -11,8 +14,60 @@ import org.junit.Test;
  */
 public class ExampleUnitTest {
 
+    private final UtilsSQLite uSqlite = new UtilsSQLite();
+
     @Test
     public void addition_isCorrect() throws Exception {
         assertEquals(4, 2 + 2);
+    }
+
+    @Test
+    public void getStatementsArray_canHandleComments() throws Exception {
+        String[] actualLines = {
+            "-- RedefineTables",
+            "PRAGMA foreign_keys = OFF;",
+            "",
+            "-- CreateTable",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);",
+        };
+
+        String[] expected = {
+            "PRAGMA foreign_keys = OFF",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);"
+        };
+
+        assertArrayEquals(
+            expected,
+            uSqlite.getStatementsArray(
+                String.join("\n", actualLines)
+            ));
+    }
+
+    @Test
+    public void getStatementsArray_canHandleWhitespace() throws Exception {
+        String[] actualLines = {
+            "-- RedefineTables",
+            "",
+            "PRAGMA foreign_keys = OFF;",
+            "",
+            "-- CreateTable",
+            "CREATE TABLE",
+            "IF NOT EXISTS key_value",
+            "--comment in the middle",
+            "",
+            "(key TEXT NOT NULL PRIMARY KEY, VALUE TEXT);",
+            ""
+        };
+
+        String[] expected = {
+            "PRAGMA foreign_keys = OFF",
+            "CREATE TABLE IF NOT EXISTS key_value (key TEXT NOT NULL PRIMARY KEY, VALUE TEXT)"
+        };
+
+        assertArrayEquals(
+            expected,
+            uSqlite.getStatementsArray(
+                String.join("\n", actualLines)
+            ));
     }
 }


### PR DESCRIPTION
I was experimenting with some migration scripts generated by Prisma Migrate. For example, to recreate a table `comment` with a new created_at column:

```sql
-- RedefineTables
PRAGMA foreign_keys=OFF;
CREATE TABLE "new_comment" (
    "id" TEXT NOT NULL PRIMARY KEY,
    "text" TEXT NOT NULL,
    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
);
INSERT INTO "new_comment" ("id", "text") SELECT "id", "text" FROM "comment";
DROP TABLE "comment";
ALTER TABLE "new_comment" RENAME TO "comment";
PRAGMA foreign_key_check;
PRAGMA foreign_keys=ON;
```

Note that Prisma likes to add some line comments like `-- CreateTable` and `-- RedefineTables`.

I called the script on Android from JavaScript with:

```js
const script = `-- RedefineTables
PRAGMA foreign_keys=OFF;
CREATE TABLE "new_comment" (
    "id" TEXT NOT NULL PRIMARY KEY,
    "text" TEXT NOT NULL,
    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
);
INSERT INTO "new_comment" ("id", "text") SELECT "id", "text" FROM "comment";
DROP TABLE "comment";
ALTER TABLE "new_comment" RENAME TO "comment";
PRAGMA foreign_key_check;
PRAGMA foreign_keys=ON;`;

CapacitorSQLite.execute({
  database: 'my_db',
  statements: script,
});
```

However, the `getStatementsArray` function on Android reformatted everything before the first `;` into a single line command like

```sql
-- RedefineTables PRAGMA foreign_keys=OFF;
```

which turned everything after the line comment `--` into part of the comment too, and caused a syntax error.

I think this could be supported simply by making getStatementsArray ignore any line that starts with "--".

While it is also possible to write sql with multiline comments and "--" comments in the same line, this would require much more advance parsing to avoid breaking valid sql using `--` or `/*` inside of literals.

```sql
SELECT "hello"; --comment
SELECT "hello" /* comment */;
SELECT "hello --not a comment";
SELECT "hello /* not a comment */";
```
